### PR TITLE
Fix setup.py failure with TypeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ elif lib_file == "wpcap.lib":
 define_macros = []
 
 if recursive_search_dirs(dirs, ['pcap-int.h']):
-        define_macros.append(('HAVE_PCAP_INT_H', 1))
+    define_macros.append(('HAVE_PCAP_INT_H', 1))
 else:
     print "No pcap-int.h found"
 
@@ -100,7 +100,7 @@ pcap = Extension(
     sources=['pcap.pyx', 'pcap_ex.c'],
     include_dirs=[include_dirs],
     define_macros=define_macros,
-    libraries=libraries,
+    libraries=list(libraries),
     extra_compile_args=extra_compile_args,
 )
 


### PR DESCRIPTION
python setup.py install fails with
`TypeError: can only concatenate tuple (not "list") to tuple`
This commit casts the libraries tuple to a list
Tested with distutils 2.7.3
