### PR TITLE
pcap_ex.c: fix immediate mode for linux

### DIFF
--- a/pcap_ex.c
+++ b/pcap_ex.c
@@ -34,9 +34,11 @@ pcap_ex_immediate(pcap_t *pcap)
 #elif defined BIOCIMMEDIATE
     int n = 1;
     return ioctl(pcap_fileno(pcap), BIOCIMMEDIATE, &n);
-#else /* XXX On OSX Yosemite (10.10.3) BIOCIMMEDIATE is not defined) */
+#elif defined __APPLE__ /* XXX On OSX Yosemite (10.10.3) BIOCIMMEDIATE is not defined) */
     int n = 1;
     return ioctl(pcap_fileno(pcap), _IOW('B',112, u_int), &n);
+#else
+    return 0;
 #endif
 }
 


### PR DESCRIPTION
Hello!

The code that sets immediate mode should also consider that apparently on Linux BIOCIMMEDIATE is not (or could be not in certain cases) included. Currently this is not done, and a MacOS specific ioctl is invoked instead. Which should explain the "couldn't enable immediate mode error" that I reported in TheTorProject/ooni-probe#472 and possibly also pynetwork/pypcap#12.

The shell session below, taken from a Vagrant precise32 test box shows that BIOCIMMEDIATE is not available in `/usr/include`. Also, with the patched pypcap, ooni-probe's tests using pypcap work on such box, while with 1.1.4 they fail (and note that they used to work with 1.1.3.).

```
vagrant@precise32:/ooni$ uname -a
Linux precise32 3.2.0-23-generic-pae #36-Ubuntu SMP Tue Apr 10 22:19:09 UTC 2012 i686 i686 i386 GNU/Linux
vagrant@precise32:/ooni$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"
vagrant@precise32:/ooni$ grep -Rn BIOCIMMEDIATE /usr/include/pcap/* /usr/include/pcap.h
vagrant@precise32:/ooni$ grep -Rn BIOCIMMEDIATE /usr/include/
vagrant@precise32:/ooni$
```
(I don't exactly know what immediate mode is. This diff just ensures that what was happening with 1.1.3 continues to happen on Linux. If there are better ways to deal with this in Linux, let me know.)

Thanks!
