### PR TITLE
pcap_file() has been in libpcap since 0.4.

### DIFF
--- a/pcap_ex.c
+++ b/pcap_ex.c
@@ -161,11 +161,7 @@ pcap_ex_fileno(pcap_t *pcap)
 	/* XXX - how to handle savefiles? */
 	return ((int)pcap_getevent(pcap));
 #else
-# ifdef HAVE_PCAP_FILE
 	FILE *f = pcap_file(pcap);
-# else
-	FILE *f = pcap->sf.rfile;
-# endif
 	if (f != NULL)
 		return (fileno(f));
 	return (pcap_fileno(pcap));

--- a/pcap_ex.c
+++ b/pcap_ex.c
@@ -14,9 +14,6 @@
 #endif
 
 #include <pcap.h>
-#ifdef HAVE_PCAP_INT_H
-#include <pcap-int.h>
-#endif
 #include "pcap_ex.h"
 
 /* XXX - hack around older Python versions */
@@ -255,11 +252,7 @@ pcap_ex_next(pcap_t *pcap, struct pcap_pkthdr **hdr, u_char **pkt)
 			return (-1);
 		}
 		if ((__pkt = (u_char *)pcap_next(pcap, &__hdr)) == NULL) {
-#ifdef HAVE_PCAP_FILE
 			if (pcap_file(pcap) != NULL)
-#else
-			if (pcap->sf.rfile != NULL)
-#endif
 				return (-2);
 			FD_ZERO(&rfds);
 			FD_SET(fd, &rfds);

--- a/setup.py
+++ b/setup.py
@@ -67,15 +67,6 @@ elif lib_file == "wpcap.lib":
 
 define_macros = []
 
-pcap_int_path = recursive_search_dirs(dirs, ['pcap-int.h'])
-if pcap_int_path:
-    pcap_int_dir = os.path.dirname(pcap_int_path)
-    if pcap_int_dir not in include_dirs:
-        include_dirs.append(pcap_int_dir)
-    define_macros.append(('HAVE_PCAP_INT_H', 1))
-else:
-    print "No pcap-int.h found"
-
 pcap_h_file = open(pcap_h).readlines()
 for line in pcap_h_file:
     if 'pcap_compile_nopcap(' in line:

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,6 @@ else:
 
 pcap_h_file = open(pcap_h).readlines()
 for line in pcap_h_file:
-    if 'pcap_file(' in line:
-        print "found pcap_file function"
-        define_macros.append(('HAVE_PCAP_FILE', 1))
     if 'pcap_compile_nopcap(' in line:
         print "found pcap_compile_nopcap function"
         define_macros.append(('HAVE_PCAP_COMPILE_NOPCAP', 1))


### PR DESCRIPTION
libpcap 0.4 came out in July 1998; I doubt any system worth caring about
has a libpcap lacking pcap_file().  Get rid of the test for pcap_file()
and the code that works around its absence.