### PR TITLE
Updated setup.py to be compatible with the latest wpdpack layout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ Python PCAP module
 This is a simplified object-oriented Python wrapper for libpcap -
 the current tcpdump.org version, and the WinPcap port for Windows.
 
-example use:
+Example use:
 
 >>> import pcap
 >>> for ts, pkt in pcap.pcap():
 ...     print ts, `pkt`
 ...
 
-Install
---------
+Installation
+------------
 
 This package requires:
 
@@ -25,6 +25,24 @@ This package requires:
 To install run::
 
     pip install pypcap
+
+
+Installation from sources
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please clone the sources and run::
+
+    python setup.py install
+
+Note for Windows users: WinPcap doesn't provide the development package, therefore
+the additional actions are required.
+Please download the latest compiled library from https://github.com/patmarion/winpcap
+and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it)::
+
+    cd ..
+    git clone https://github.com/patmarion/winpcap.git wpdpack
+    cd pypcap
+    python setup.py install
 
 
 Support

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,14 @@ import os
 import sys
 import re
 
+
 def recursive_search_dirs(dirs, target_files):
     """Recursive search directories"""
     for d in dirs:
         r = recursive_search(d, target_files)
         if r:
             return r
+
 
 def recursive_search(path, target_files):
     """Recursively search for files"""
@@ -19,17 +21,20 @@ def recursive_search(path, target_files):
             if filename in target_files:
                 return os.path.join(root, filename)
 
+
 # A list of all the possible search directories
 dirs = ['/usr', sys.prefix] + glob.glob('/opt/libpcap*') + \
     glob.glob('../libpcap*') + glob.glob('../wpdpack*') + \
-    glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*')
+    glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/' +
+              'MacOSX.platform/Developer/SDKs/*')
 
 for d in dirs:
-    # This makes sure that we first search inside of */include/pcap
-    search_dirs = [os.path.join(d, 'usr', 'include', 'pcap'),
-                   os.path.join(d, 'include', 'pcap'),
-                   os.path.join(d, 'local', 'include', 'pcap'),
-                   d]
+    search_dirs = [
+        os.path.join(d, 'local', 'include'),
+        os.path.join(d, 'usr', 'include'),
+        os.path.join(d, 'include'),
+        d
+    ]
 
     pcap_h = recursive_search_dirs(search_dirs, ['pcap.h'])
     if pcap_h:
@@ -43,9 +48,21 @@ if not pcap_h:
 include_dirs = [os.path.dirname(pcap_h)]
 
 # This logic will use the path 'd' that the pcap.h was found in
-lib_sub_dirs = [os.path.join(d, sub_dir) \
-        for sub_dir in ('lib', 'lib64', \
-        'lib/x86_64-linux-gnu', 'lib/i386-linux-gnu', '')]
+is_64bits = sys.maxsize > 2**32
+priority_libs = (
+    'lib64',
+    'lib/x64',  # wpdpack
+    'lib/x86_64-linux-gnu'
+) if is_64bits else tuple()
+
+lib_sub_dirs = [
+    os.path.join(d, sub_dir)
+    for sub_dir in priority_libs + (
+        'lib',
+        'lib/i386-linux-gnu',
+        ''
+    )
+]
 
 # For Mac OSX the default system pcap lib is in /usr/lib
 lib_sub_dirs.append('/usr/lib')
@@ -61,6 +78,7 @@ lib_file_path = recursive_search_dirs(lib_sub_dirs, lib_files)
 print("Found libraries in %s" % lib_file_path)
 
 lib_file = os.path.basename(lib_file_path)
+lib_path = os.path.dirname(lib_file_path)
 
 extra_compile_args = []
 if re.match(r"libpcap\.(a|so|dylib)", lib_file):
@@ -92,6 +110,7 @@ pcap = Extension(
     sources=['pcap.c', 'pcap_ex.c'],
     include_dirs=include_dirs,
     define_macros=define_macros,
+    library_dirs=[lib_path, ],
     libraries=list(libraries),
     extra_compile_args=extra_compile_args,
 )


### PR DESCRIPTION
PR to address #35 (at least, partially). Unfortunately, the proposed precompiled libraries (and the official previous versions of WinPcap development packages) are not compatible with the setup.py search directories, so I had to fix it. Also, there was x86/x64 linking issue, I've fixed it too.

The solution is not ideal, and it's better to download the Windows libraries automatically, and I hope to address it in near future.