### PR TITLE
More useful example has been added.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,10 @@ the current tcpdump.org version, and the WinPcap port for Windows.
 Example use:
 
 >>> import pcap
->>> for ts, pkt in pcap.pcap():
-...     print ts, `pkt`
+>>> sniffer = pcap.pcap(name=None, promisc=True, immediate=True)
+>>> addr = lambda pkt, offset: '.'.join(str(ord(pkt[i])) for i in xrange(offset, offset + 4)).ljust(16)
+>>> for ts, pkt in sniffer:
+...     print ts, '\tSRC', addr(pkt, sniffer.dloff + 12), '\tDST', addr(pkt, sniffer.dloff + 16)
 ...
 
 Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,12 +7,15 @@ Example use:
 ::
 
     >>> import pcap
-    >>> for ts, pkt in pcap.pcap():
-    ...     print ts, `pkt`
+    >>> sniffer = pcap.pcap(name=None, promisc=True, immediate=True)
+    >>> addr = lambda pkt, offset: '.'.join(str(ord(pkt[i])) for i in xrange(offset, offset + 4)).ljust(16)
+    >>> for ts, pkt in sniffer:
+    ...     print ts, '\tSRC', addr(pkt, sniffer.dloff + 12), '\tDST', addr(pkt, sniffer.dloff + 16)
     ...
 
-Install
---------
+
+Installation
+------------
 
 This package requires:
 
@@ -24,6 +27,24 @@ To install run
 ::
 
     pip install pypcap
+
+
+Installation from sources
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please clone the sources and run::
+
+    python setup.py install
+
+Note for Windows users: WinPcap doesn't provide the development package, therefore
+the additional actions are required.
+Please download the latest compiled library from https://github.com/patmarion/winpcap
+and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it)::
+
+    cd ..
+    git clone https://github.com/patmarion/winpcap.git wpdpack
+    cd pypcap
+    python setup.py install
 
 
 Support


### PR DESCRIPTION
The original example can't immediately show that pypcap is working properly (it doesn't print anything), so I've changed it to be a little bit more useful (verified in macOS and CentOS).

Unfortunately, it proved that Windows version with the proposed libraries (see my previous pull request) does not work properly in Windows 10, so I'm going to research and fix the issue.

P. S. I'm not sure how to update readthedocs, and I've updated the original docs sources only. If "docs" changes require any additional actions, please let me know.