### PR TITLE
Avoid packet buffer overwriting.

### DIFF
--- a/pcap.pyx
+++ b/pcap.pyx
@@ -20,7 +20,7 @@ import sys
 import struct
 
 cdef extern from "Python.h":
-    object PyBuffer_FromMemory(char *s, int len)
+    object PyString_FromStringAndSize(char *v, int len)
     int    PyObject_AsCharBuffer(object obj, char **buffer, int *buffer_len)
     int    PyGILState_Ensure()
     void   PyGILState_Release(int gil)
@@ -107,7 +107,7 @@ cdef void __pcap_handler(void *arg, pcap_pkthdr *hdr, char *pkt):
     gil = PyGILState_Ensure()
     try:
         (<object>ctx.callback)(hdr.ts.tv_sec + (hdr.ts.tv_usec/1000000.0),
-                               PyBuffer_FromMemory(pkt, hdr.caplen),
+                               PyString_FromStringAndSize(pkt, hdr.caplen),
                                *(<object>ctx.args))
     except:
         ctx.got_exc = 1
@@ -333,7 +333,7 @@ cdef class pcap:
             Py_END_ALLOW_THREADS
             if n == 1:
                 callback(hdr.ts.tv_sec + (hdr.ts.tv_usec / 1000000.0),
-                         PyBuffer_FromMemory(pkt, hdr.caplen), *args)
+                         PyString_FromStringAndSize(pkt, hdr.caplen), *args)
             elif n == 0:
                 break
             elif n == -1:
@@ -377,7 +377,7 @@ cdef class pcap:
             Py_END_ALLOW_THREADS
             if n == 1:
                 return (hdr.ts.tv_sec + (hdr.ts.tv_usec / 1000000.0),
-                        PyBuffer_FromMemory(pkt, hdr.caplen))
+                        PyString_FromStringAndSize(pkt, hdr.caplen))
             elif n == 0:
                 return None
             elif n == -1:


### PR DESCRIPTION
Use PyString_FromStringAndSize instead of PyBuffer_FromMemory to make sure
packets buffers are not unintentionally shared.