### PR TITLE
Additional Windows notes have been added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,19 @@ Example use:
 ...     print ts, '\tSRC', addr(pkt, sniffer.dloff + 12), '\tDST', addr(pkt, sniffer.dloff + 16)
 ...
 
+
+Windows notes
+-------------
+
+WinPcap has the compatibility issues with Windows 10, therefore
+it's recommended to use `Npcap <https://nmap.org/npcap/>`_
+(Nmap's packet sniffing library for Windows, based on the WinPcap/Libpcap libraries, but with improved speed, portability, security, and efficiency). Please enable WinPcap API-compatible mode during the library installation.
+
+The sample installation using `Chocolatey <https://chocolatey.org/>`_::
+
+    choco install -y npcap --ia '/winpcap_mode=yes'
+
+
 Installation
 ------------
 
@@ -36,13 +49,13 @@ Please clone the sources and run::
 
     python setup.py install
 
-Note for Windows users: WinPcap doesn't provide the development package, therefore
-the additional actions are required.
-Please download the latest compiled library from https://github.com/patmarion/winpcap
-and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it)::
+Note for Windows users: Please download the `WinPcap Developer's Pack <https://www.winpcap.org/devel.htm>`_, unpack the archive and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it).
+
+Sample procedure in PowerShell::
 
     cd ..
-    git clone https://github.com/patmarion/winpcap.git wpdpack
+    wget -usebasicparsing -outfile WpdPack_4_1_2.zip http://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+    unzip WpdPack_4_1_2.zip
     cd pypcap
     python setup.py install
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Example use:
 Windows notes
 -------------
 
-WinPcap has the compatibility issues with Windows 10, therefore
+WinPcap has compatibility issues with Windows 10, therefore
 it's recommended to use `Npcap <https://nmap.org/npcap/>`_
 (Nmap's packet sniffing library for Windows, based on the WinPcap/Libpcap libraries, but with improved speed, portability, security, and efficiency). Please enable WinPcap API-compatible mode during the library installation.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autodoc_member_order = 'bysource'
 
 # -- Options for HTML output --------------------------------------------------
 html_theme = 'default'
-html_static_path = ['_static']
+html_static_path = []
 
 html_use_modindex = True
 html_use_index = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Example use:
 Windows notes
 -------------
 
-WinPcap has the compatibility issues with Windows 10, therefore
+WinPcap has compatibility issues with Windows 10, therefore
 it's recommended to use `Npcap <https://nmap.org/npcap/>`_
 (Nmap's packet sniffing library for Windows, based on the WinPcap/Libpcap libraries, but with improved speed, portability, security, and efficiency). Please enable WinPcap API-compatible mode during the library installation.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,18 @@ Example use:
     ...
 
 
+Windows notes
+-------------
+
+WinPcap has the compatibility issues with Windows 10, therefore
+it's recommended to use `Npcap <https://nmap.org/npcap/>`_
+(Nmap's packet sniffing library for Windows, based on the WinPcap/Libpcap libraries, but with improved speed, portability, security, and efficiency). Please enable WinPcap API-compatible mode during the library installation.
+
+The sample installation using `Chocolatey <https://chocolatey.org/>`_::
+
+    choco install -y npcap --ia '/winpcap_mode=yes'
+
+
 Installation
 ------------
 
@@ -36,13 +48,13 @@ Please clone the sources and run::
 
     python setup.py install
 
-Note for Windows users: WinPcap doesn't provide the development package, therefore
-the additional actions are required.
-Please download the latest compiled library from https://github.com/patmarion/winpcap
-and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it)::
+Note for Windows users: Please download the `WinPcap Developer's Pack <https://www.winpcap.org/devel.htm>`_, unpack the archive and put it into the sibling directory as ``wpdpack`` (``setup.py`` will discover it).
+
+Sample procedure in PowerShell::
 
     cd ..
-    git clone https://github.com/patmarion/winpcap.git wpdpack
+    wget -usebasicparsing -outfile WpdPack_4_1_2.zip http://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+    unzip WpdPack_4_1_2.zip
     cd pypcap
     python setup.py install
 


### PR DESCRIPTION
WinPcap is not working with Win10 properly, I've added a note about Npcap. Development libs from old WinPcap is still working though, so I've updated the links and the procedure to point out the correct libs.

Additional notes: Npcap has its own SDK that is compatible with WinPcap, but the released version has a bug with the redefinition of vnsprinf, I hope they'll eventually update the SDK and the bug vanishes. Also Win10 sniffing has some performance issues, I guess it's because of blocking calls to pcap_next_ex, but non-blocking calls (with timeout specified) are not working. I'm going to fix it (please note that this involves pyx and C changes).