### PR TITLE
Fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 """Setup for pycapy"""
 from setuptools import setup, Extension
+from itertools import chain
+from io import open
 import glob
 import os
 import sys
-import re
 
 PACKAGE = "pypcap"
 VERSION = "1.2.1"
@@ -25,49 +26,51 @@ def recursive_search(path, target_files):
                 return os.path.join(root, filename)
 
 
-def get_extension():
-    # A list of all the possible search directories
-    dirs = ['/usr', sys.prefix] + glob.glob('/opt/libpcap*') + \
-        glob.glob('../libpcap*') + glob.glob('../wpdpack*') + \
-        glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/' +
-                  'MacOSX.platform/Developer/SDKs/*')
+def find_prefix_and_pcap_h():
+    prefixes = chain.from_iterable((
+        ('/usr', sys.prefix),
+        glob.glob('/opt/libpcap*'),
+        glob.glob('../libpcap*'),
+        glob.glob('../wpdpack*'),
+        glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*'),
+    ))
 
-    for d in dirs:
-        search_dirs = [
-            os.path.join(d, 'local', 'include'),
-            os.path.join(d, 'usr', 'include'),
-            os.path.join(d, 'include'),
-            d
-        ]
+    # Find 'pcap.h'
+    for prefix in prefixes:
+        search_dirs = (
+            os.path.join(prefix, 'local', 'include'),
+            os.path.join(prefix, 'usr', 'include'),
+            os.path.join(prefix, 'include'),
+            prefix,
+        )
 
         pcap_h = recursive_search_dirs(search_dirs, ['pcap.h'])
         if pcap_h:
             print("Found pcap headers in %s" % pcap_h)
-            break
+            return (prefix, pcap_h)
+    print("pcap.h not found")
+    sys.exit(1)
 
-    if not pcap_h:
-        print("pcap.h not found")
-        sys.exit(1)
 
-    include_dirs = [os.path.dirname(pcap_h)]
-
-    # This logic will use the path 'd' that the pcap.h was found in
-    is_64bits = sys.maxsize > 2**32
-    priority_libs = (
-        'lib64',
-        'lib/x64',  # wpdpack
-        'lib/x86_64-linux-gnu'
-    ) if is_64bits else tuple()
-
-    lib_sub_dirs = [
-        os.path.join(d, sub_dir)
-        for sub_dir in priority_libs + (
+def find_lib_path_and_file(prefix):
+    if sys.maxsize > 2 ** 32:
+        candidates = [
+            'lib64',
+            'lib/x64',  # wpdpack
+            'lib/x86_64-linux-gnu'
             'lib',
             'lib/i386-linux-gnu',
             ''
-        )
+        ]
+    else:
+        candidates = [
+            'lib',
+            'lib/i386-linux-gnu',
+            ''
+        ]
+    lib_sub_dirs = [
+        os.path.join(prefix, d) for d in candidates
     ]
-
     # For Mac OSX the default system pcap lib is in /usr/lib
     lib_sub_dirs.append('/usr/lib')
 
@@ -78,58 +81,66 @@ def get_extension():
         'wpcap.lib'
     ]
     lib_file_path = recursive_search_dirs(lib_sub_dirs, lib_files)
-
+    if not lib_file_path:
+        print("None of the following found: %s" % lib_files)
+        sys.exit(1)
+        return
     print("Found libraries in %s" % lib_file_path)
 
-    lib_file = os.path.basename(lib_file_path)
     lib_path = os.path.dirname(lib_file_path)
+    lib_file = os.path.basename(lib_file_path)
+    return lib_path, lib_file
 
-    extra_compile_args = []
-    if re.match(r"libpcap\.(a|so|dylib)", lib_file):
-        libraries = ('pcap',)
-    elif lib_file == "wpcap.lib":
-        libraries = ('wpcap', 'iphlpapi')
+
+def find_define_macros(pcap_h):
+    with open(pcap_h, 'r',
+              encoding='utf-8',
+              errors='surrogateescape') as fi:
+        for line in fi.readlines():
+            if 'pcap_file(' in line:
+                print("found pcap_file function")
+                yield ('HAVE_PCAP_FILE', 1)
+            elif 'pcap_compile_nopcap(' in line:
+                print("found pcap_compile_nopcap function")
+                yield ('HAVE_PCAP_COMPILE_NOPCAP', 1)
+            elif 'pcap_setnonblock(' in line:
+                print("found pcap_setnonblock")
+                yield ('HAVE_PCAP_SETNONBLOCK', 1)
+            elif 'pcap_setdirection(' in line:
+                print("found pcap_setdirection")
+                yield ('HAVE_PCAP_SETDIRECTION', 1)
+
+
+def get_extension():
+    prefix, pcap_h = find_prefix_and_pcap_h()
+    lib_path, lib_file = find_lib_path_and_file(prefix)
+
+    if lib_file == 'wpcap.lib':
+        libraries = ['wpcap', 'iphlpapi']
         extra_compile_args = ['-DWIN32', '-DWPCAP', '-D_CRT_SECURE_NO_WARNINGS']
+    else:
+        libraries = ['pcap']
+        extra_compile_args = []
 
-    define_macros = []
-
-    pcap_h_file = open(pcap_h).readlines()
-    for line in pcap_h_file:
-        if 'pcap_file(' in line:
-            print("found pcap_file function")
-            define_macros.append(('HAVE_PCAP_FILE', 1))
-        if 'pcap_compile_nopcap(' in line:
-            print("found pcap_compile_nopcap function")
-            define_macros.append(('HAVE_PCAP_COMPILE_NOPCAP', 1))
-        if 'pcap_setnonblock(' in line:
-            print("found pcap_setnonblock")
-            define_macros.append(('HAVE_PCAP_SETNONBLOCK', 1))
-        if 'pcap_setdirection(' in line:
-            print("found pcap_setdirection")
-            define_macros.append(('HAVE_PCAP_SETDIRECTION', 1))
-
-    ext = Extension(
+    return Extension(
         name='pcap',
         sources=['pcap.c', 'pcap_ex.c'],
-        include_dirs=include_dirs,
-        define_macros=define_macros,
-        library_dirs=[lib_path, ],
-        libraries=list(libraries),
+        include_dirs=[os.path.dirname(pcap_h)],
+        define_macros=list(find_define_macros(pcap_h)),
+        library_dirs=[lib_path],
+        libraries=libraries,
         extra_compile_args=extra_compile_args
     )
-    return ext
 
-setup_args = dict(
-    name=PACKAGE,
-    version=VERSION,
-    author='Dug Song',
-    author_email='dugsong@monkey.org',
-    url='https://github.com/pynetwork/pypcap',
-    description='pypcap -- Python interface to pcap a packet capture library',
-    tests_require=['dpkt']
-)
 
-if __name__ == "__main__":
-    ext = get_extension()
-    setup_args['ext_modules'] = [ext]
-    setup(**setup_args)
+if __name__ == '__main__':
+    setup(
+        name=PACKAGE,
+        version=VERSION,
+        author='Dug Song',
+        author_email='dugsong@monkey.org',
+        url='https://github.com/pynetwork/pypcap',
+        description='pypcap -- Python interface to pcap a packet capture library',
+        tests_require=['dpkt'],
+        ext_modules=[get_extension()],
+    )

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,11 @@ def find_lib_path_and_file(prefix):
 
 
 def find_define_macros(pcap_h):
+    alternative = os.path.join(os.path.dirname(pcap_h), 'pcap', 'pcap.h')
+    if os.path.exists(alternative):
+        # Read pcap/pcap.h as well
+        for macro in find_define_macros(alternative):
+            yield macro
     with open(pcap_h, 'r',
               encoding='utf-8',
               errors='surrogateescape') as fi:


### PR DESCRIPTION
This PR closes the following issues

- #70 - Fixed by showing `None of the followings found ["libpcap.a", "libpcap.so", ..., "wpcap.lib"]` and exit with exitcode 1
- #68 - Fixed by reading `pcap/pcap.h` as well to determine macros.

##### Windows 10 Pro + Python 3.6

```
$ python setup.py bdist
Found pcap headers in ..\wpdpack\include\pcap.h
Found libraries in ..\wpdpack\lib/x64\wpcap.lib
found pcap_setdirection
found pcap_setnonblock
found pcap_compile_nopcap function
found pcap_file function
running bdist
running bdist_dumb
running build
running build_ext
building 'pcap' extension
creating build
creating build\temp.win-amd64-3.6
creating build\temp.win-amd64-3.6\Release
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DHAVE_PCAP_SETDIRECTION=1 -DHAVE_PCAP_SETNONBLOCK=1 -DHAVE_PCAP_COMPILE_NOPCAP=1 -DHAVE_PCAP_FILE=1 -I..\wpdpack\include -IC:\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\include -IC:\Python36\include -IC:\Python36\include "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\8.1\include\shared" "-IC:\Program Files (x86)\Windows Kits\8.1\include\um" "-IC:\Program Files (x86)\Windows Kits\8.1\include\winrt" /Tcpcap.c /Fobuild\temp.win-amd64-3.6\Release\pcap.obj -DWIN32 -DWPCAP -D_CRT_SECURE_NO_WARNINGS
pcap.c
pcap.c(19904): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26219): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26239): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26240): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26244): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26246): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26253): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26255): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26262): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26264): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26284): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26287): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26294): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26295): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26296): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26300): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26302): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26309): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26311): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26318): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26320): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26327): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26329): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26336): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26338): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26345): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26347): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26354): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26357): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26386): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26391): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26399): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26403): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
pcap.c(26408): warning C4197: '__pyx_atomic_int': top-level volatile in cast is ignored
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DHAVE_PCAP_SETDIRECTION=1 -DHAVE_PCAP_SETNONBLOCK=1 -DHAVE_PCAP_COMPILE_NOPCAP=1 -DHAVE_PCAP_FILE=1 -I..\wpdpack\include -IC:\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\include -IC:\Python36\include -IC:\Python36\include "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\8.1\include\shared" "-IC:\Program Files (x86)\Windows Kits\8.1\include\um" "-IC:\Program Files (x86)\Windows Kits\8.1\include\winrt" /Tcpcap_ex.c /Fobuild\temp.win-amd64-3.6\Release\pcap_ex.obj -DWIN32 -DWPCAP -D_CRT_SECURE_NO_WARNINGS
pcap_ex.c
pcap_ex.c(134): warning C4311: 'type cast': pointer truncation from 'HANDLE' to 'int'
creating C:\Users\alisue\Code\github.com\lambdalisue\pypcap\build\lib.win-amd64-3.6
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\link.exe /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:..\wpdpack\lib/x64 /LIBPATH:C:\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\libs /LIBPATH:C:\Python36\libs /LIBPATH:C:\Python36 /LIBPATH:C:\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\LIB\amd64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.10240.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\8.1\lib\winv6.3\um\x64" wpcap.lib iphlpapi.lib /EXPORT:PyInit_pcap build\temp.win-amd64-3.6\Release\pcap.obj build\temp.win-amd64-3.6\Release\pcap_ex.obj /OUT:build\lib.win-amd64-3.6\pcap.cp36-win_amd64.pyd /IMPLIB:build\temp.win-amd64-3.6\Release\pcap.cp36-win_amd64.lib
pcap.obj : warning LNK4197: export 'PyInit_pcap' specified multiple times; using first specification
   Creating library build\temp.win-amd64-3.6\Release\pcap.cp36-win_amd64.lib and object build\temp.win-amd64-3.6\Release\pcap.cp36-win_amd64.exp
Generating code
Finished generating code
installing to build\bdist.win-amd64\dumb
running install
running install_lib
creating build\bdist.win-amd64
creating build\bdist.win-amd64\dumb
creating build\bdist.win-amd64\dumb\Users
creating build\bdist.win-amd64\dumb\Users\alisue
creating build\bdist.win-amd64\dumb\Users\alisue\Code
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib
creating build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages
copying build\lib.win-amd64-3.6\pcap.cp36-win_amd64.pyd -> build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages
running install_egg_info
running egg_info
writing pypcap.egg-info\PKG-INFO
writing dependency_links to pypcap.egg-info\dependency_links.txt
writing top-level names to pypcap.egg-info\top_level.txt
reading manifest file 'pypcap.egg-info\SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pypcap.egg-info\SOURCES.txt'
Copying pypcap.egg-info to build\bdist.win-amd64\dumb\Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pypcap-1.2.1-py3.6.egg-info
running install_scripts
creating C:\Users\alisue\Code\github.com\lambdalisue\pypcap\dist
creating 'C:\Users\alisue\Code\github.com\lambdalisue\pypcap\dist\pypcap-1.2.1.win-amd64.zip' and adding '.' to it
adding 'Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pcap.cp36-win_amd64.pyd'
adding 'Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pypcap-1.2.1-py3.6.egg-info\dependency_links.txt'
adding 'Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pypcap-1.2.1-py3.6.egg-info\PKG-INFO'
adding 'Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pypcap-1.2.1-py3.6.egg-info\SOURCES.txt'
adding 'Users\alisue\Code\github.com\lambdalisue\pypcap\.venv\Lib\site-packages\pypcap-1.2.1-py3.6.egg-info\top_level.txt'
removing 'build\bdist.win-amd64\dumb' (and everything under it)
```

##### macOS High Sierra + Python 3.6

```
$ python setup.py bdist
Found pcap headers in /usr/include/pcap.h
Found libraries in /usr/lib/libpcap.dylib
found pcap_setdirection
found pcap_setnonblock
found pcap_compile_nopcap function
found pcap_file function
running bdist
running bdist_dumb
running build
running build_ext
building 'pcap' extension
creating build
creating build/temp.macosx-10.13-x86_64-3.6
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DHAVE_PCAP_SETDIRECTION=1 -DHAVE_PCAP_SETNONBLOCK=1 -DHAVE_PCAP_COMPILE_NOPCAP=1 -DHAVE_PCAP_FILE=1 -I/usr/include -I/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/include -I/Users/alisue/.anyenv/envs/pyenv/versions/3.6.4/include/python3.6m -c pcap.c -o build/temp.macosx-10.13-x86_64-3.6/pcap.o
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DHAVE_PCAP_SETDIRECTION=1 -DHAVE_PCAP_SETNONBLOCK=1 -DHAVE_PCAP_COMPILE_NOPCAP=1 -DHAVE_PCAP_FILE=1 -I/usr/include -I/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/include -I/Users/alisue/.anyenv/envs/pyenv/versions/3.6.4/include/python3.6m -c pcap_ex.c -o build/temp.macosx-10.13-x86_64-3.6/pcap_ex.o
creating build/lib.macosx-10.13-x86_64-3.6
clang -bundle -undefined dynamic_lookup -L/usr/local/opt/readline/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/openssl/lib -L/Users/alisue/.anyenv/envs/pyenv/versions/3.6.4/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/openssl/lib -L/Users/alisue/.anyenv/envs/pyenv/versions/3.6.4/lib build/temp.macosx-10.13-x86_64-3.6/pcap.o build/temp.macosx-10.13-x86_64-3.6/pcap_ex.o -L/usr/lib -lpcap -o build/lib.macosx-10.13-x86_64-3.6/pcap.cpython-36m-darwin.so
installing to build/bdist.macosx-10.13-x86_64/dumb
running install
running install_lib
creating build/bdist.macosx-10.13-x86_64
creating build/bdist.macosx-10.13-x86_64/dumb
creating build/bdist.macosx-10.13-x86_64/dumb/Users
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/lib
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/lib/python3.6
creating build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/lib/python3.6/site-packages
copying build/lib.macosx-10.13-x86_64-3.6/pcap.cpython-36m-darwin.so -> build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/lib/python3.6/site-packages
running install_egg_info
running egg_info
writing pypcap.egg-info/PKG-INFO
writing dependency_links to pypcap.egg-info/dependency_links.txt
writing top-level names to pypcap.egg-info/top_level.txt
reading manifest file 'pypcap.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pypcap.egg-info/SOURCES.txt'
Copying pypcap.egg-info to build/bdist.macosx-10.13-x86_64/dumb/Users/alisue/Code/github.com/lambdalisue/pypcap/.venv/lib/python3.6/site-packages/pypcap-1.2.1-py3.6.egg-info
running install_scripts
creating /Users/alisue/Code/github.com/lambdalisue/pypcap/dist
Creating tar archive
removing 'build/bdist.macosx-10.13-x86_64/dumb' (and everything under it)
```

##### Check
```python
import pcap

p = pcap.pcap(pcap.findalldevs()[0])
print('non-blocking:', p.getnonblock())
p.setnonblock()
print('non-blocking:', p.getnonblock())
```

```
non-blocking: False
non-blocking: True
```