### PR TITLE
setup.py: support new CLT SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ def find_prefix_and_pcap_h():
         glob.glob('../libpcap*'),
         glob.glob('../wpdpack*'),
         glob.glob('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*'),
+        glob.glob('/Library/Developer/CommandLineTools/SDKs/*'),
     ))
 
     # Find 'pcap.h'


### PR DESCRIPTION
As of macOS 10.14 installing the Command Line Tools will no longer create `/usr/include`, which is an intentional change by Apple. The headers are permanently moving inside the SDK, which is now provided by both Xcode and the CLT package.

Xcode is already supported here but people are considerably more likely to have the CLT installed due to it being a much more lightweight installation than the full Xcode IDE. This change ensures that once macOS Mojave/10.14 lands installation won't suddenly break, regardless of which of the CLT/Xcode choice people choose to go with.

Without this change the build bails out on:
```
Running command python setup.py egg_info
    pcap.h not found
Cleaning up...
```