### PR TITLE
We don't use HAVE_PCAP_FILE, so we don't need to check for pcap_file().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,10 +103,7 @@ def find_define_macros(pcap_h):
               encoding='utf-8',
               errors='surrogateescape') as fi:
         for line in fi.readlines():
-            if 'pcap_file(' in line:
-                print("found pcap_file function")
-                yield ('HAVE_PCAP_FILE', 1)
-            elif 'pcap_compile_nopcap(' in line:
+            if 'pcap_compile_nopcap(' in line:
                 print("found pcap_compile_nopcap function")
                 yield ('HAVE_PCAP_COMPILE_NOPCAP', 1)
             elif 'pcap_setnonblock(' in line:


### PR DESCRIPTION
Subject says it all. Earlier pull requests of mine, getting rid of the checks of `HAVE_PCAP_FILE`, were merged, but this part of my request wasn't.